### PR TITLE
Add body link edges sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This plugin enhances the Obsidian canvas with a wide array of features:
     *   [Full Metadata Cache Support](#full-metadata-cache-support): Integrate canvases with Obsidian's graph view, outgoing links, and backlinks.
     *   [Frontmatter Support](#frontmatter-support): Add custom properties to canvas files.
     *   [Auto File Node Edges](#auto-file-node-edges): Automatically create edges between file nodes based on their frontmatter properties.
+    *   [Body Link Edges](#body-link-edges): Sync edges with lines like `- [label] [[file]]` inside your notes.
     *   [Single Node Links & Embeds](#single-node-links--embeds): Link or embed a single node from a canvas into markdown files.
     *   [Better Default Settings](#better-default-settings): Customize default node sizes, grid alignment, and more.
     *   [Enhanced Readonly Mode](#better-readonly): Finer control over canvas interaction in readonly mode.
@@ -136,6 +137,9 @@ This significantly enhances the ability to manage, organize, and customize your 
 
 ## Auto File Node Edges
 Advanced Canvas can automatically create edges between file nodes based on their frontmatter properties. By default (if enabled), it will create edges to files linked in the `canvas-edges` frontmatter property. This allows you to create fixed relationships between file nodes in your canvas, making it easier to visualize fixed structures or connections between different files.
+
+## Body Link Edges
+Edges can also be synced using list items inside your notes. Lines formatted as `- [label] [[Target Note]]` will automatically create an edge labeled `label` from the note to the target file when the canvas loads. Creating an edge between two file nodes with a label will append the same line to the source file.
 
 ### Single Node Links & Embeds
 Advanced Canvas now allows you to link or embed the content of a *single node* from a `.canvas` file directly into your markdown files. This provides a granular way to reference specific pieces of information within your canvases.

--- a/src/canvas-extensions/body-link-edges-canvas-extension.ts
+++ b/src/canvas-extensions/body-link-edges-canvas-extension.ts
@@ -1,0 +1,143 @@
+import { TFile } from "obsidian"
+import CanvasExtension from "./canvas-extension"
+import { Canvas, CanvasNode, CanvasEdge } from "src/@types/Canvas"
+import { CanvasEdgeData } from "src/@types/AdvancedJsonCanvas"
+import BBoxHelper from "src/utils/bbox-helper"
+import CanvasHelper from "src/utils/canvas-helper"
+
+const BODY_EDGE_ID_PREFIX = "ble"
+const BULLET_LINK_REGEX = /^\s*-\s*\[([^\]]+)\]\s*\[\[([^\]]+)\]\]/
+
+export default class BodyLinkEdgesCanvasExtension extends CanvasExtension {
+  isEnabled() { return 'bodyLinkEdgesFeatureEnabled' as const }
+
+  init() {
+    this.plugin.registerEvent(this.plugin.app.vault.on('modify', (file: TFile) => {
+      for (const canvas of this.plugin.getCanvases())
+        this.onFileModified(canvas, file)
+    }))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-added',
+      (canvas: Canvas, node: CanvasNode) => this.onNodeChanged(canvas, node)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-changed',
+      (canvas: Canvas, node: CanvasNode) => this.onNodeChanged(canvas, node)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-added',
+      (canvas: Canvas, edge: CanvasEdge) => this.onEdgeChanged(canvas, edge)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-changed',
+      (canvas: Canvas, edge: CanvasEdge) => this.onEdgeChanged(canvas, edge)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-removed',
+      (canvas: Canvas, edge: CanvasEdge) => this.onEdgeRemoved(canvas, edge)
+    ))
+  }
+
+  private async onFileModified(canvas: Canvas, file: TFile) {
+    for (const node of canvas.nodes.values()) {
+      if (node.getData().type !== 'file' || node.file?.path !== file.path) continue
+      await this.updateBodyEdges(canvas, node)
+    }
+  }
+
+  private async onNodeChanged(canvas: Canvas, _node: CanvasNode) {
+    for (const node of canvas.nodes.values()) {
+      if (node.getData().type !== 'file') continue
+      await this.updateBodyEdges(canvas, node)
+    }
+  }
+
+  private async onEdgeChanged(canvas: Canvas, edge: CanvasEdge) {
+    const edgeData = edge.getData()
+    const from = edge.from.node
+    const to = edge.to.node
+    if (from.getData().type !== 'file' || to.getData().type !== 'file') return
+    if (!edgeData.label) return
+    if (!from.file || !to.file) return
+
+    const linktext = this.plugin.app.metadataCache.fileToLinktext(to.file, from.file.path)
+    const line = `- [${edgeData.label}] [[${linktext}]]`
+    let content = await this.plugin.app.vault.cachedRead(from.file)
+    if (!content.split(/\n/).some(l => l.trim() === line.trim())) {
+      if (!content.endsWith('\n')) content += '\n'
+      content += line + '\n'
+      await this.plugin.app.vault.modify(from.file, content)
+    }
+  }
+
+  private async onEdgeRemoved(canvas: Canvas, edge: CanvasEdge) {
+    const edgeData = edge.getData()
+    const from = edge.from.node
+    const to = edge.to.node
+    if (from.getData().type !== 'file' || to.getData().type !== 'file') return
+    if (!from.file || !to.file) return
+
+    const linktext = this.plugin.app.metadataCache.fileToLinktext(to.file, from.file.path)
+    const line = `- [${edgeData.label ?? ''}] [[${linktext}]]`
+    let content = await this.plugin.app.vault.cachedRead(from.file)
+    const lines = content.split(/\n/)
+    const filtered = lines.filter(l => l.trim() !== line.trim())
+    if (lines.length !== filtered.length) {
+      await this.plugin.app.vault.modify(from.file, filtered.join('\n'))
+    }
+  }
+
+  private async updateBodyEdges(canvas: Canvas, node: CanvasNode) {
+    const edges = await this.getBodyEdges(canvas, node)
+    const newEdges = Array.from(edges.values()).filter(edge => !canvas.edges.has(edge.id))
+    canvas.importData({ nodes: [], edges: newEdges }, false, false)
+    for (const edge of canvas.edges.values()) {
+      if (edge.id.startsWith(`${BODY_EDGE_ID_PREFIX}${node.id}`) && !edges.has(edge.id))
+        canvas.removeEdge(edge)
+    }
+  }
+
+  private async getBodyEdges(canvas: Canvas, node: CanvasNode): Promise<Map<string, CanvasEdgeData>> {
+    if (!node.file) return new Map()
+    const canvasFile = canvas.view.file
+    if (!canvasFile) return new Map()
+
+    const content = await this.plugin.app.vault.cachedRead(node.file)
+    const lines = content.split(/\n/)
+    const nodes = Array.from(canvas.nodes.values())
+    const edges: Map<string, CanvasEdgeData> = new Map()
+    let idx = 0
+
+    for (const line of lines) {
+      const match = line.match(BULLET_LINK_REGEX)
+      if (!match) continue
+      const label = match[1].trim()
+      const link = match[2].split('|')[0].trim()
+      const targetFile = this.plugin.app.metadataCache.getFirstLinkpathDest(link, canvasFile.path)
+      const targetNode = nodes.find(n => n.id !== node.id && n.getData().type === 'file' && n.file?.path === targetFile?.path)
+      if (!targetNode) continue
+
+      const edgeId = `${BODY_EDGE_ID_PREFIX}${node.id}${targetNode.id}-${idx++}`
+      const bestFromSide = CanvasHelper.getBestSideForFloatingEdge(BBoxHelper.getCenterOfBBoxSide(targetNode.getBBox(), 'right'), node)
+      const bestToSide = CanvasHelper.getBestSideForFloatingEdge(BBoxHelper.getCenterOfBBoxSide(node.getBBox(), 'left'), targetNode)
+
+      edges.set(edgeId, {
+        id: edgeId,
+        fromNode: node.id,
+        fromSide: bestFromSide,
+        fromFloating: true,
+        toNode: targetNode.id,
+        toSide: bestToSide,
+        toFloating: true,
+        label
+      })
+    }
+
+    return edges
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import FlipEdgeCanvasExtension from './canvas-extensions/flip-edge-canvas-extens
 import ExportCanvasExtension from './canvas-extensions/export-canvas-extension'
 import FloatingEdgeCanvasExtension from './canvas-extensions/floating-edge-canvas-extension'
 import EdgeHighlightCanvasExtension from './canvas-extensions/edge-highlight-canvas-extension'
+import BodyLinkEdgesCanvasExtension from './canvas-extensions/body-link-edges-canvas-extension'
 
 // Advanced Styles
 import NodeStylesExtension from './canvas-extensions/advanced-styles/node-styles'
@@ -96,6 +97,7 @@ const CANVAS_EXTENSIONS: typeof CanvasExtension[] = [
   VariableBreakpointCanvasExtension,
   EdgeHighlightCanvasExtension,
   AutoFileNodeEdgesCanvasExtension,
+  BodyLinkEdgesCanvasExtension,
   FlipEdgeCanvasExtension,
   ZOrderingCanvasExtension,
   ExportCanvasExtension,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -101,6 +101,8 @@ export interface AdvancedCanvasPluginSettingsValues {
   autoFileNodeEdgesFeatureEnabled: boolean
   autoFileNodeEdgesFrontmatterKey: string
 
+  bodyLinkEdgesFeatureEnabled: boolean
+
   edgeHighlightEnabled: boolean
   highlightIncomingEdges: boolean
 }
@@ -193,6 +195,8 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
 
   autoFileNodeEdgesFeatureEnabled: false,
   autoFileNodeEdgesFrontmatterKey: 'canvas-edges',
+
+  bodyLinkEdgesFeatureEnabled: false,
 
   edgeHighlightEnabled: false,
   highlightIncomingEdges: false,
@@ -317,6 +321,11 @@ export const SETTINGS = {
         parse: (value: string) => value.trim() || 'canvas-edges'
       }
     }
+  },
+  bodyLinkEdgesFeatureEnabled: {
+    label: 'Body link edges',
+    description: 'Create edges based on lines formatted as "- [label] [[file]]" and update notes when edges are made.',
+    children: { }
   },
   portalsFeatureEnabled: {
     label: 'Portals',


### PR DESCRIPTION
## Summary
- sync edges with list items using Body Link Edges extension
- document new Body Link Edges feature

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68491ebb8a388328bfdb21dd6fc27a31